### PR TITLE
chore: make deadtime for grasp a parameter

### DIFF
--- a/src/screwmpc_experiments/experiments/common.py
+++ b/src/screwmpc_experiments/experiments/common.py
@@ -96,6 +96,12 @@ def create_argparser() -> argparse.ArgumentParser:
         action="store_true",
         help="set the robot control thread priority to realtime",
     )
+    parser.add_argument(
+        "--grasp-time",
+        type=float,
+        help="Time to wait for a grasp to complete",
+        default=2.0,
+    )
     return parser
 
 
@@ -109,4 +115,5 @@ def create_agent(
         args.sclerp,
         args.manipulability,
         args.output,
+        grasp_time=args.grasp_time,
     )

--- a/src/screwmpc_experiments/experiments/screwmpc.py
+++ b/src/screwmpc_experiments/experiments/screwmpc.py
@@ -91,6 +91,7 @@ class ScrewMPCAgent:
         sclerp: float,
         use_mp: bool = False,
         output_file: str = "obs.csv",
+        grasp_time: float = 2.0,
     ) -> None:
         self._spec = spec
         self._goal_tolerance = goal_tolerance
@@ -103,6 +104,7 @@ class ScrewMPCAgent:
         self._output_file = output_file
         self._finished = False
         self._dead_time = 0.0
+        self._grasp_time = grasp_time
         self.init_screwmpc()
         self.init_xmlrpc()
 
@@ -162,7 +164,7 @@ class ScrewMPCAgent:
                     and x_goal[2] != self._x_goal[2]
                 ):
                     logger.info("Grasping")
-                    self._dead_time = timestep.observation["time"][0] + 1
+                    self._dead_time = timestep.observation["time"][0] + self._grasp_time
                 else:
                     logger.info("Tracking new goal: %s", self._goal)
                 self._x_goal = x_goal


### PR DESCRIPTION
Use `--grasp-time` to set the time in seconds to wait for a grasp action to complete.