### PR TITLE
use reduced gradient for manipulability maximization

### DIFF
--- a/src/screwmpc_experiments/experiments/screwmpc.py
+++ b/src/screwmpc_experiments/experiments/screwmpc.py
@@ -648,7 +648,7 @@ def create_screwmpc(sclerp: float, use_mp: bool) -> pandamg.PandaScrewMotionGene
     vel_bound = screwmpc.BOUND(lb_v, ub_v)
 
     generator = (
-        pandamg.PandaScrewMpMotionGenerator
+        pandamg.PandaScrewMpRGMotionGenerator
         if use_mp
         else pandamg.PandaScrewMotionGenerator
     )


### PR DESCRIPTION
Initial manipulability maximization taken from [here](https://arxiv.org/abs/2002.11901) allows end-effector to deviate from screw motion.

Changes:
- Use the [Reduced Gradient](https://www.sciencedirect.com/science/article/pii/S1474667017517255) method to achieve manipulability maximization in nullspace.